### PR TITLE
Add automatic Open Graph image generation

### DIFF
--- a/src/app/[...path]/opengraph-image.tsx
+++ b/src/app/[...path]/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { config, pages } from "#site/content";
+import { createOgImage, ogImageContentType, ogImageSize } from "@/utils/og";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const alt = "Page open graph image";
+
+type Params = { path: string[] };
+
+type OgImageProps = {
+    params: Promise<Params>;
+};
+
+type PageEntry = (typeof pages)[number];
+type LegacyPageEntry = PageEntry & { originalPath?: string };
+
+function getLegacyOriginalPath(page: PageEntry): string | undefined {
+    const candidate = (page as LegacyPageEntry).originalPath;
+    return typeof candidate === "string" ? candidate : undefined;
+}
+
+function joinPath(segments: string[]): string {
+    return segments.join("/");
+}
+
+function getPageByPath(segments: string[]) {
+    const target = joinPath(segments);
+    return pages.find(page => {
+        const legacyOriginalPath = getLegacyOriginalPath(page);
+        return page.path === target ||
+            page.permalink === `/${target}` ||
+            legacyOriginalPath === target ||
+            legacyOriginalPath === `pages/${target}`;
+    });
+}
+
+export default async function OgImage({ params }: OgImageProps) {
+    const resolvedParams = await params;
+    const page = getPageByPath(resolvedParams.path);
+
+    if (!page) {
+        return createOgImage({
+            title: config.site_info.title,
+            align: "center",
+        });
+    }
+
+    return createOgImage({
+        title: page.title,
+        subtitle: config.site_info.title,
+        align: "start",
+    });
+}

--- a/src/app/[...path]/page.tsx
+++ b/src/app/[...path]/page.tsx
@@ -54,9 +54,19 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     const { path } = resolvedParams;
     const page = getPageByPath(path);
     if (page == null) return {};
+    const description = page.description;
     return {
         title: page.title,
-        description: page.description,
+        description,
+        openGraph: {
+            title: page.title,
+            description,
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: page.title,
+            description,
+        },
     };
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,9 +17,27 @@ type RootLayoutProps = {
 const inter = Inter({ subsets: ["latin"] });
 
 // TODO: metadata
+const siteTitle = config.site_info.title;
+const siteDescription = `by ${config.site_info.author}`;
+
 export const metadata: Metadata = {
-    title: `${config.site_info.title}`,
-    description: `by ${config.site_info.author}`,
+    title: {
+        default: siteTitle,
+        template: `%s | ${siteTitle}`,
+    },
+    description: siteDescription,
+    openGraph: {
+        title: siteTitle,
+        description: siteDescription,
+        type: "website",
+        siteName: siteTitle,
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: siteTitle,
+        description: siteDescription,
+    },
+    themeColor: config.site_info.theme_color,
 };
 
 export default function RootLayout({ children }: RootLayoutProps) {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { config } from "#site/content";
+import { createOgImage, ogImageContentType, ogImageSize } from "@/utils/og";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const alt = `${config.site_info.title} open graph image`;
+
+export default function OgImage() {
+    return createOgImage({
+        title: config.site_info.title,
+        align: "center",
+    });
+}

--- a/src/app/posts/[...path]/opengraph-image.tsx
+++ b/src/app/posts/[...path]/opengraph-image.tsx
@@ -1,0 +1,39 @@
+import { config, posts } from "#site/content";
+import { createOgImage, ogImageContentType, ogImageSize } from "@/utils/og";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const alt = "Post open graph image";
+
+type Params = { path: string[] };
+
+type OgImageProps = {
+    params: Promise<Params>;
+};
+
+function normalise(path: string) {
+    return path.replace(/^posts\//, "");
+}
+
+function getPostByPath(segments: string[]) {
+    const joined = segments.join("/");
+    return posts.find(post => "path" in post && normalise((post as any).path) === joined);
+}
+
+export default async function OgImage({ params }: OgImageProps) {
+    const resolvedParams = await params;
+    const post = getPostByPath(resolvedParams.path);
+
+    if (!post) {
+        return createOgImage({
+            title: config.site_info.title,
+            align: "center",
+        });
+    }
+
+    return createOgImage({
+        title: post.title,
+        subtitle: config.site_info.title,
+        align: "start",
+    });
+}

--- a/src/app/posts/[...path]/page.tsx
+++ b/src/app/posts/[...path]/page.tsx
@@ -31,7 +31,23 @@ function getPostByPath(pathArr: string[]) {
 export async function generateMetadata({ params }: PostProps): Promise<Metadata> {
     const resolvedParams = await params;
     const post = getPostByPath(resolvedParams.path);
-    return post ? { title: post.title, description: post.excerpt } : {};
+    if (!post) return {};
+
+    const description = post.excerpt;
+
+    return {
+        title: post.title,
+        description,
+        openGraph: {
+            title: post.title,
+            description,
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: post.title,
+            description,
+        },
+    };
 }
 
 /* -------------------------------------------------- */

--- a/src/app/tags/[slug]/opengraph-image.tsx
+++ b/src/app/tags/[slug]/opengraph-image.tsx
@@ -1,0 +1,30 @@
+import { config } from "#site/content";
+import { createOgImage, ogImageContentType, ogImageSize } from "@/utils/og";
+
+export const size = ogImageSize;
+export const contentType = ogImageContentType;
+export const alt = "Tag open graph image";
+
+type Params = { slug: string };
+
+type OgImageProps = {
+    params: Promise<Params>;
+};
+
+export default async function OgImage({ params }: OgImageProps) {
+    const resolvedParams = await params;
+    const tag = decodeURIComponent(resolvedParams.slug);
+
+    if (!tag) {
+        return createOgImage({
+            title: config.site_info.title,
+            align: "center",
+        });
+    }
+
+    return createOgImage({
+        title: `Tag: ${tag}`,
+        subtitle: config.site_info.title,
+        align: "start",
+    });
+}

--- a/src/app/tags/[slug]/page.tsx
+++ b/src/app/tags/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { getPosts } from "@/app/actions/getPosts";
 import PostList from "@/components/ui/Posts/list";
 import Tag from "@/components/ui/Tags";
@@ -16,6 +17,27 @@ export function generateStaticParams(): { slug: string }[] {
     return uniqueTags.map((tag: string) => ({
         slug: tag
     }));
+}
+
+export async function generateMetadata({ params }: TagProps): Promise<Metadata> {
+    const resolvedParams = await params;
+    const tag = decodeURIComponent(resolvedParams.slug);
+    const title = `Tag: ${tag}`;
+    const description = `Posts tagged with ${tag} on ${config.site_info.title}`;
+
+    return {
+        title,
+        description,
+        openGraph: {
+            title,
+            description,
+        },
+        twitter: {
+            card: "summary_large_image",
+            title,
+            description,
+        },
+    };
 }
 
 export default async function TagPage({ params }: TagProps) {

--- a/src/utils/og.tsx
+++ b/src/utils/og.tsx
@@ -1,0 +1,147 @@
+import { ImageResponse } from "next/og";
+import { config } from "#site/content";
+
+const DEFAULT_THEME_COLOR = "#6366F1";
+
+const OG_WIDTH = 1200;
+const OG_HEIGHT = 630;
+
+const white = { r: 255, g: 255, b: 255 } as const;
+const black = { r: 0, g: 0, b: 0 } as const;
+
+type RGB = { r: number; g: number; b: number };
+
+type OgImageOptions = {
+    title: string;
+    subtitle?: string;
+    align?: "center" | "start";
+};
+
+function normaliseHex(hex: string): string {
+    const trimmed = hex.trim();
+    if (/^#?[0-9a-fA-F]{3}$/.test(trimmed)) {
+        const withoutHash = trimmed.replace(/^#/, "");
+        const [r, g, b] = withoutHash.split("");
+        return `#${r}${r}${g}${g}${b}${b}`;
+    }
+
+    if (/^#?[0-9a-fA-F]{6}$/.test(trimmed)) {
+        return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+    }
+
+    return DEFAULT_THEME_COLOR;
+}
+
+function hexToRgb(hex: string): RGB {
+    const normalised = normaliseHex(hex).replace("#", "");
+    return {
+        r: parseInt(normalised.slice(0, 2), 16),
+        g: parseInt(normalised.slice(2, 4), 16),
+        b: parseInt(normalised.slice(4, 6), 16),
+    };
+}
+
+function rgbToHex({ r, g, b }: RGB): string {
+    const clamp = (value: number) => Math.max(0, Math.min(255, Math.round(value)));
+    return `#${clamp(r).toString(16).padStart(2, "0")}${clamp(g).toString(16).padStart(2, "0")}${clamp(b).toString(16).padStart(2, "0")}`;
+}
+
+function mix(base: RGB, target: RGB, amount: number): RGB {
+    return {
+        r: base.r + (target.r - base.r) * amount,
+        g: base.g + (target.g - base.g) * amount,
+        b: base.b + (target.b - base.b) * amount,
+    };
+}
+
+function lighten(hex: string, amount: number): string {
+    return rgbToHex(mix(hexToRgb(hex), white, amount));
+}
+
+function darken(hex: string, amount: number): string {
+    return rgbToHex(mix(hexToRgb(hex), black, amount));
+}
+
+export function createOgImage({ title, subtitle, align = "start" }: OgImageOptions) {
+    const baseColor = config.site_info?.theme_color ?? DEFAULT_THEME_COLOR;
+    const accentLight = lighten(baseColor, 0.35);
+    const accentDark = darken(baseColor, 0.25);
+
+    const isCentered = align === "center";
+
+    return new ImageResponse(
+        (
+            <div
+                style={{
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    position: "relative",
+                    backgroundImage: `linear-gradient(135deg, ${accentDark}, ${baseColor}, ${accentLight})`,
+                    color: "#0f172a",
+                    fontFamily: "'Inter', 'Plus Jakarta Sans', 'Noto Sans JP', sans-serif",
+                    justifyContent: "center",
+                    alignItems: "center",
+                }}
+            >
+                <div
+                    style={{
+                        position: "absolute",
+                        inset: 48,
+                        borderRadius: 40,
+                        border: "4px solid rgba(255,255,255,0.25)",
+                        backgroundColor: "rgba(255,255,255,0.82)",
+                        display: "flex",
+                        flexDirection: "column",
+                        justifyContent: "center",
+                        padding: "72px 96px",
+                        boxShadow: "0 30px 80px rgba(15,23,42,0.25)",
+                    }}
+                >
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 24,
+                            textAlign: isCentered ? "center" : "left",
+                            alignItems: isCentered ? "center" : "flex-start",
+                        }}
+                    >
+                        <span
+                            style={{
+                                fontSize: isCentered ? 96 : 78,
+                                fontWeight: 700,
+                                lineHeight: 1.05,
+                                color: "#111827",
+                                textShadow: "0 14px 30px rgba(148,163,184,0.45)",
+                                maxWidth: isCentered ? 820 : 920,
+                                wordBreak: "break-word",
+                            }}
+                        >
+                            {title}
+                        </span>
+                        {subtitle ? (
+                            <span
+                                style={{
+                                    fontSize: isCentered ? 40 : 34,
+                                    fontWeight: 500,
+                                    color: "rgba(30,41,59,0.75)",
+                                    maxWidth: 880,
+                                }}
+                            >
+                                {subtitle}
+                            </span>
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+        ),
+        {
+            width: OG_WIDTH,
+            height: OG_HEIGHT,
+        }
+    );
+}
+
+export const ogImageSize = { width: OG_WIDTH, height: OG_HEIGHT } as const;
+export const ogImageContentType = "image/png" as const;


### PR DESCRIPTION
## Summary
- add a shared helper to generate branded Open Graph images using the site theme color
- serve dynamic OG images for the home, page, post, and tag routes with appropriate titles
- enrich metadata defaults with Open Graph and Twitter cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d86a57f4d08323b24f80a5e308abb1