### PR TITLE
Add automatic Open Graph image generation

### DIFF
--- a/src/app/(home)/opengraph-image.tsx
+++ b/src/app/(home)/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { config } from "#site/content";
+import { createOgImage, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/utils/og";
+
+export const runtime = "edge";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_IMAGE_CONTENT_TYPE;
+export const alt = `${config.site_info.title} – Open Graph image`;
+
+export default function HomeOgImage() {
+    return createOgImage({ title: config.site_info.title });
+}

--- a/src/app/[...path]/opengraph-image.tsx
+++ b/src/app/[...path]/opengraph-image.tsx
@@ -1,0 +1,40 @@
+import { config, pages } from "#site/content";
+import { createOgImage, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/utils/og";
+
+export const runtime = "edge";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_IMAGE_CONTENT_TYPE;
+export const alt = `${config.site_info.title} page preview`;
+
+type Params = {
+    path?: string[];
+};
+
+function joinPath(segments: string[]) {
+    return segments.join("/");
+}
+
+function getPageByPath(segments: string[]) {
+    const target = joinPath(segments);
+    return pages.find(page => {
+        const legacyOriginalPath = (page as Record<string, unknown>).originalPath;
+        const legacy = typeof legacyOriginalPath === "string" ? legacyOriginalPath : undefined;
+        return (
+            page.path === target ||
+            page.permalink === `/${target}` ||
+            legacy === target ||
+            legacy === `pages/${target}`
+        );
+    });
+}
+
+export default function PageOgImage({ params }: { params: Params }) {
+    const segments = Array.isArray(params?.path) ? params.path : [];
+    const page = getPageByPath(segments);
+    const title = page?.title ?? config.site_info.title;
+
+    return createOgImage({
+        title,
+        subtitle: page ? config.site_info.title : undefined,
+    });
+}

--- a/src/app/posts/[...path]/opengraph-image.tsx
+++ b/src/app/posts/[...path]/opengraph-image.tsx
@@ -1,0 +1,35 @@
+import { config, posts } from "#site/content";
+import { createOgImage, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/utils/og";
+
+export const runtime = "edge";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_IMAGE_CONTENT_TYPE;
+export const alt = `${config.site_info.title} post preview`;
+
+type Params = {
+    path?: string[];
+};
+
+function normalise(path: string) {
+    return path.replace(/^posts\//, "");
+}
+
+function getPostByPath(segments: string[]) {
+    const target = segments.join("/");
+    return posts.find(post => {
+        const rawPath = (post as Record<string, unknown>).path;
+        if (typeof rawPath !== "string") return false;
+        return normalise(rawPath) === target;
+    });
+}
+
+export default function PostOgImage({ params }: { params: Params }) {
+    const segments = Array.isArray(params?.path) ? params.path : [];
+    const post = getPostByPath(segments);
+    const title = post?.title ?? config.site_info.title;
+
+    return createOgImage({
+        title,
+        subtitle: post ? config.site_info.title : undefined,
+    });
+}

--- a/src/app/posts/opengraph-image.tsx
+++ b/src/app/posts/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { config } from "#site/content";
+import { createOgImage, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/utils/og";
+
+export const runtime = "edge";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_IMAGE_CONTENT_TYPE;
+export const alt = `${config.site_info.title} posts overview`;
+
+export default function PostsIndexOgImage() {
+    return createOgImage({
+        title: "All Posts",
+        subtitle: config.site_info.title,
+    });
+}

--- a/src/app/tags/opengraph-image.tsx
+++ b/src/app/tags/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { config } from "#site/content";
+import { createOgImage, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/utils/og";
+
+export const runtime = "edge";
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_IMAGE_CONTENT_TYPE;
+export const alt = `${config.site_info.title} tags`;
+
+export default function TagsOgImage() {
+    return createOgImage({
+        title: "All Tags",
+        subtitle: config.site_info.title,
+    });
+}

--- a/src/utils/og.tsx
+++ b/src/utils/og.tsx
@@ -1,0 +1,134 @@
+import { ImageResponse } from "next/og";
+import { config } from "#site/content";
+import { generateColorPalette } from "@/utils/themeColor";
+
+export const OG_IMAGE_SIZE = { width: 1200, height: 630 } as const;
+export const OG_IMAGE_CONTENT_TYPE = "image/png" as const;
+
+const palette = generateColorPalette(
+    config.site_info.theme_color,
+    config.site_info.theme_color_hue_shift
+);
+
+function hexToRgb(hex: string) {
+    const stripped = hex.replace("#", "");
+    const normalized =
+        stripped.length === 3
+            ? stripped
+                  .split("")
+                  .map(char => char + char)
+                  .join("")
+            : stripped;
+    const truncated = normalized.slice(0, 6);
+    const bigint = parseInt(truncated, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return { r, g, b };
+}
+
+function rgba(hex: string, alpha: number) {
+    const { r, g, b } = hexToRgb(hex);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+type CreateOgImageOptions = {
+    title: string;
+    subtitle?: string;
+};
+
+export function createOgImage({ title, subtitle }: CreateOgImageOptions) {
+    const safeTitle = title || config.site_info.title;
+    const showSubtitle = Boolean(subtitle);
+
+    const gradient = `linear-gradient(135deg, ${palette[700]}, ${palette[400]})`;
+    const backdrop = rgba(palette[900], 0.55);
+    const accent = rgba(palette[100], 0.45);
+
+    return new ImageResponse(
+        (
+            <div
+                style={{
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundImage: gradient,
+                    position: "relative",
+                    fontFamily: '"Inter", "Noto Sans", "Segoe UI", sans-serif',
+                    color: "#f8fafc",
+                    letterSpacing: "0.02em",
+                }}
+            >
+                <div
+                    style={{
+                        position: "absolute",
+                        inset: 0,
+                        background: `radial-gradient(circle at 20% 20%, ${rgba(palette[200], 0.35)}, transparent 60%)`,
+                    }}
+                />
+                <div
+                    style={{
+                        position: "absolute",
+                        inset: 0,
+                        background: `radial-gradient(circle at 80% 30%, ${rgba(palette[500], 0.25)}, transparent 55%)`,
+                    }}
+                />
+                <div
+                    style={{
+                        position: "absolute",
+                        inset: 48,
+                        borderRadius: 48,
+                        backgroundColor: backdrop,
+                        boxShadow: `0 40px 120px ${rgba(palette[900], 0.35)}`,
+                        border: `2px solid ${accent}`,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        padding: "72px 64px",
+                    }}
+                >
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            alignItems: "center",
+                            textAlign: "center",
+                            width: "100%",
+                            gap: showSubtitle ? 36 : 24,
+                        }}
+                    >
+                        <div
+                            style={{
+                                fontSize: showSubtitle ? 88 : 104,
+                                fontWeight: 700,
+                                lineHeight: 1.05,
+                                textShadow: `0 12px 32px ${rgba("#000000", 0.35)}`,
+                                maxWidth: "90%",
+                            }}
+                        >
+                            {safeTitle}
+                        </div>
+                        {showSubtitle ? (
+                            <div
+                                style={{
+                                    fontSize: 36,
+                                    fontWeight: 500,
+                                    opacity: 0.85,
+                                    textTransform: "uppercase",
+                                    letterSpacing: "0.16em",
+                                }}
+                            >
+                                {subtitle}
+                            </div>
+                        ) : null}
+                    </div>
+                </div>
+            </div>
+        ),
+        {
+            ...OG_IMAGE_SIZE,
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared Open Graph image helper that renders branded cards from the configured theme palette
- generate automatic Open Graph images for the home page, dynamic pages, posts, and the tags index using the helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d86a57f4d08323b24f80a5e308abb1