### PR TITLE
feat: simplify theme toggle and add view transition animation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    experimental: {
+        viewTransition: true,
+    },
     images: {
         remotePatterns: [
             {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,37 +29,22 @@ body {
 
     ::view-transition-new(root) {
         --theme-transition-radius: 0px;
-        mask-image: radial-gradient(
-            circle var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y),
-            rgb(255 255 255 / 1) 0%,
-            rgb(255 255 255 / 1) 60%,
-            rgb(255 255 255 / 0) 100%
-        );
-        mask-mode: alpha;
-        mask-repeat: no-repeat;
-        mask-size: 100% 100%;
+        clip-path: circle(var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y));
         animation: theme-switch-reveal 420ms var(--expo-out) forwards;
+        z-index: 1;
     }
 
     ::view-transition-old(root),
     .dark::view-transition-old(root) {
-        --theme-transition-radius: 350vmax;
-        mask-image: radial-gradient(
-            circle var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y),
-            rgb(255 255 255 / 1) 0%,
-            rgb(255 255 255 / 1) 60%,
-            rgb(255 255 255 / 0) 100%
-        );
-        mask-mode: alpha;
-        mask-repeat: no-repeat;
-        mask-size: 100% 100%;
+        --theme-transition-radius: 150vmax;
+        clip-path: circle(var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y));
         animation: theme-switch-conceal 420ms var(--expo-out) forwards;
         z-index: -1;
     }
 
     @keyframes theme-switch-reveal {
         to {
-            --theme-transition-radius: 350vmax;
+            --theme-transition-radius: 150vmax;
         }
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,24 +22,39 @@ body {
     }
 
     ::view-transition-new(root) {
-        mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
-            var(--theme-transition-x) var(--theme-transition-y) / 0 no-repeat;
-        mask-origin: content-box;
-        mask-size: 0;
-        animation: theme-switch-scale 0.9s;
-        transform-origin: var(--theme-transition-x) var(--theme-transition-y);
+        clip-path: circle(0rem at var(--theme-transition-x) var(--theme-transition-y));
+        animation: theme-switch-reveal 420ms var(--expo-out);
+        animation-fill-mode: forwards;
     }
 
     ::view-transition-old(root),
     .dark::view-transition-old(root) {
-        animation: theme-switch-scale 0.9s;
-        transform-origin: var(--theme-transition-x) var(--theme-transition-y);
+        clip-path: circle(150% at var(--theme-transition-x) var(--theme-transition-y));
+        animation: theme-switch-conceal 420ms var(--expo-out);
+        animation-fill-mode: forwards;
         z-index: -1;
     }
 
-    @keyframes theme-switch-scale {
+    @keyframes theme-switch-reveal {
         to {
-            mask-size: 350vmax 350vmax;
+            clip-path: circle(150% at var(--theme-transition-x) var(--theme-transition-y));
+        }
+    }
+
+    @keyframes theme-switch-conceal {
+        to {
+            clip-path: circle(0rem at var(--theme-transition-x) var(--theme-transition-y));
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        ::view-transition-group(root),
+        ::view-transition-new(root),
+        ::view-transition-old(root),
+        .dark::view-transition-old(root) {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1;
+            animation-fill-mode: both;
         }
     }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,7 @@
 :root {
     --theme-transition-x: 50vw;
     --theme-transition-y: 50vh;
+    --theme-transition-duration: 420ms;
     --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -30,16 +31,14 @@ body {
     ::view-transition-new(root) {
         --theme-transition-radius: 0px;
         clip-path: circle(var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y));
-        animation: theme-switch-reveal 420ms var(--expo-out) forwards;
+        animation: theme-switch-reveal var(--theme-transition-duration) var(--expo-out) forwards;
         z-index: 1;
     }
 
     ::view-transition-old(root),
     .dark::view-transition-old(root) {
-        --theme-transition-radius: 150vmax;
-        clip-path: circle(var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y));
-        animation: theme-switch-conceal 420ms var(--expo-out) forwards;
-        z-index: -1;
+        animation: theme-switch-fade var(--theme-transition-duration) var(--expo-out) forwards;
+        z-index: 0;
     }
 
     @keyframes theme-switch-reveal {
@@ -48,9 +47,17 @@ body {
         }
     }
 
-    @keyframes theme-switch-conceal {
+    @keyframes theme-switch-fade {
+        from {
+            opacity: 1;
+        }
+
+        60% {
+            opacity: 1;
+        }
+
         to {
-            --theme-transition-radius: 0px;
+            opacity: 0;
         }
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
 :root {
     --theme-transition-x: 50vw;
     --theme-transition-y: 50vh;
-    --theme-transition-duration: 420ms;
+    --theme-transition-duration: 1s;
     --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,12 @@
     --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+@property --theme-transition-radius {
+    syntax: "<length-percentage>";
+    inherits: false;
+    initial-value: 0px;
+}
+
 :root {
     view-transition-name: root;
 }
@@ -22,28 +28,44 @@ body {
     }
 
     ::view-transition-new(root) {
-        clip-path: circle(0rem at var(--theme-transition-x) var(--theme-transition-y));
-        animation: theme-switch-reveal 420ms var(--expo-out);
-        animation-fill-mode: forwards;
+        --theme-transition-radius: 0px;
+        mask-image: radial-gradient(
+            circle var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y),
+            rgb(255 255 255 / 1) 0%,
+            rgb(255 255 255 / 1) 60%,
+            rgb(255 255 255 / 0) 100%
+        );
+        mask-mode: alpha;
+        mask-repeat: no-repeat;
+        mask-size: 100% 100%;
+        animation: theme-switch-reveal 420ms var(--expo-out) forwards;
     }
 
     ::view-transition-old(root),
     .dark::view-transition-old(root) {
-        clip-path: circle(150% at var(--theme-transition-x) var(--theme-transition-y));
-        animation: theme-switch-conceal 420ms var(--expo-out);
-        animation-fill-mode: forwards;
+        --theme-transition-radius: 350vmax;
+        mask-image: radial-gradient(
+            circle var(--theme-transition-radius) at var(--theme-transition-x) var(--theme-transition-y),
+            rgb(255 255 255 / 1) 0%,
+            rgb(255 255 255 / 1) 60%,
+            rgb(255 255 255 / 0) 100%
+        );
+        mask-mode: alpha;
+        mask-repeat: no-repeat;
+        mask-size: 100% 100%;
+        animation: theme-switch-conceal 420ms var(--expo-out) forwards;
         z-index: -1;
     }
 
     @keyframes theme-switch-reveal {
         to {
-            clip-path: circle(150% at var(--theme-transition-x) var(--theme-transition-y));
+            --theme-transition-radius: 350vmax;
         }
     }
 
     @keyframes theme-switch-conceal {
         to {
-            clip-path: circle(0rem at var(--theme-transition-x) var(--theme-transition-y));
+            --theme-transition-radius: 0px;
         }
     }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,48 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+    --theme-transition-x: 50vw;
+    --theme-transition-y: 50vh;
+    --expo-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+:root {
+    view-transition-name: root;
+}
+
+body {
+    view-transition-name: none;
+}
+
+@supports (view-transition-name: root) {
+    ::view-transition-group(root) {
+        animation-timing-function: var(--expo-out);
+    }
+
+    ::view-transition-new(root) {
+        mask: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><defs><filter id="blur"><feGaussianBlur stdDeviation="2"/></filter></defs><circle cx="0" cy="0" r="18" fill="white" filter="url(%23blur)"/></svg>')
+            var(--theme-transition-x) var(--theme-transition-y) / 0 no-repeat;
+        mask-origin: content-box;
+        mask-size: 0;
+        animation: theme-switch-scale 0.9s;
+        transform-origin: var(--theme-transition-x) var(--theme-transition-y);
+    }
+
+    ::view-transition-old(root),
+    .dark::view-transition-old(root) {
+        animation: theme-switch-scale 0.9s;
+        transform-origin: var(--theme-transition-x) var(--theme-transition-y);
+        z-index: -1;
+    }
+
+    @keyframes theme-switch-scale {
+        to {
+            mask-size: 350vmax 350vmax;
+        }
+    }
+}
+
 .light {
     --scrollbar: theme('colors.theme.500');
     --scrollbar-bg: theme('colors.theme.200');

--- a/src/components/Layout/UtilityButtons/ThemeSwitch.tsx
+++ b/src/components/Layout/UtilityButtons/ThemeSwitch.tsx
@@ -71,14 +71,8 @@ const ThemeSwitch = () => {
             document.documentElement.style.setProperty("--theme-transition-x", `${x}px`);
             document.documentElement.style.setProperty("--theme-transition-y", `${y}px`);
 
-            const transition = doc.startViewTransition(async () => {
+            const transition = doc.startViewTransition(() => {
                 applyTheme();
-
-                await new Promise<void>((resolve) => {
-                    requestAnimationFrame(() => {
-                        requestAnimationFrame(() => resolve());
-                    });
-                });
             });
 
             transition.finished.finally(() => {

--- a/src/components/Layout/UtilityButtons/ThemeSwitch.tsx
+++ b/src/components/Layout/UtilityButtons/ThemeSwitch.tsx
@@ -71,8 +71,14 @@ const ThemeSwitch = () => {
             document.documentElement.style.setProperty("--theme-transition-x", `${x}px`);
             document.documentElement.style.setProperty("--theme-transition-y", `${y}px`);
 
-            const transition = doc.startViewTransition(() => {
+            const transition = doc.startViewTransition(async () => {
                 applyTheme();
+
+                await new Promise<void>((resolve) => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(() => resolve());
+                    });
+                });
             });
 
             transition.finished.finally(() => {

--- a/src/components/Layout/UtilityButtons/ThemeSwitch.tsx
+++ b/src/components/Layout/UtilityButtons/ThemeSwitch.tsx
@@ -1,176 +1,109 @@
 "use client";
 
-import React, { useRef, useEffect, useCallback } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { atom, useAtom } from "jotai";
-import { BiSun , BiMoon, BiDesktop, BiMobile } from "react-icons/bi";
+import { BiMoon, BiSun } from "react-icons/bi";
 import { useTheme } from "next-themes";
-import { cn } from "@/utils/cn";
-import * as Portal from "@radix-ui/react-portal";
 
 type ThemeOption = "dark" | "light" | "system";
 
 const themeAtom = atom<ThemeOption>("system");
-const isHoldingAtom = atom(false);
-const highlightedOptionAtom = atom<ThemeOption | null>(null);
-const resolveThemeAtom = atom(false);
+const themeReadyAtom = atom(false);
+
+type DocumentWithViewTransition = Document & {
+    startViewTransition?: (callback: () => void | Promise<void>) => {
+        finished: Promise<void>;
+    };
+};
 
 const ThemeSwitch = () => {
-    const [switchTheme, setSwitchTheme] = useAtom(themeAtom);
-    const [isHolding, setIsHolding] = useAtom(isHoldingAtom);
-    const [highlightedOption, setHighlightedOption] = useAtom(highlightedOptionAtom);
-    const [isThemeResolved, setIsThemeResolved] = useAtom(resolveThemeAtom);
+    const [currentTheme, setCurrentTheme] = useAtom(themeAtom);
+    const [isThemeReady, setIsThemeReady] = useAtom(themeReadyAtom);
     const buttonRef = useRef<HTMLButtonElement | null>(null);
-    const stadiumRef = useRef<HTMLDivElement | null>(null);
-    const holdTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-    const isClickedRef = useRef(false);
-    const { setTheme, resolvedTheme } = useTheme();
+    const { resolvedTheme, setTheme, theme } = useTheme();
 
     useEffect(() => {
-        if (resolvedTheme) {
-            setSwitchTheme(resolvedTheme as ThemeOption);
-            setIsThemeResolved(true);
-        }
-    }, [resolvedTheme, setIsThemeResolved, setSwitchTheme]);
-
-    const getSelectedOption = useCallback((mouseX: number, mouseY: number): ThemeOption | null => {
-        if (stadiumRef.current) {
-            const { left, top, width, height } = stadiumRef.current.getBoundingClientRect();
-            const centerX = left + width / 2;
-            const centerY = top + height / 2;
-
-            const distances = [
-                { option: "dark", distance: Math.sqrt(Math.pow(mouseX - (left + width / 6), 2) + Math.pow(mouseY - centerY, 2)) },
-                { option: "system", distance: Math.sqrt(Math.pow(mouseX - centerX, 2) + Math.pow(mouseY - centerY, 2)) },
-                { option: "light", distance: Math.sqrt(Math.pow(mouseX - (left + width * 5 / 6), 2) + Math.pow(mouseY - centerY, 2)) },
-            ];
-
-            return distances.reduce((prev, curr) => (prev.distance < curr.distance ? prev : curr)).option as ThemeOption;
-        }
-        return null;
-    }, []);
-
-    const handleMouseDown = () => {
-        isClickedRef.current = true;
-        holdTimeoutRef.current = setTimeout(() => {
-            if (isClickedRef.current) {
-                setIsHolding(true);
-            }
-        }, 500);
-    };
-
-    const handleMouseMove = useCallback((e: MouseEvent) => {
-        if (isHolding) {
-            const selectedOption = getSelectedOption(e.clientX, e.clientY);
-            setHighlightedOption(selectedOption);
-        }
-    }, [isHolding, getSelectedOption, setHighlightedOption]);
-
-    const handleMouseUp = useCallback((e: MouseEvent) => {
-        if (holdTimeoutRef.current) {
-            clearTimeout(holdTimeoutRef.current);
-        }
-        if (isHolding) {
-            const selectedOption = getSelectedOption(e.clientX, e.clientY);
-            const newTheme = selectedOption || switchTheme;
-            setSwitchTheme(newTheme);
-            setTheme(newTheme);
-            setIsHolding(false);
-        }
-        isClickedRef.current = false;
-    }, [isHolding, getSelectedOption, switchTheme, setSwitchTheme, setTheme, setIsHolding]);
-
-    useEffect(() => {
-        if (isHolding) {
-            window.addEventListener("mousemove", handleMouseMove);
-            window.addEventListener("mouseup", handleMouseUp);
+        if (!resolvedTheme) {
+            return;
         }
 
-        return () => {
-            window.removeEventListener("mousemove", handleMouseMove);
-            window.removeEventListener("mouseup", handleMouseUp);
+        const nextTheme = (theme === "system" ? "system" : resolvedTheme) as ThemeOption;
+        setCurrentTheme(nextTheme);
+        setIsThemeReady(true);
+    }, [resolvedTheme, setCurrentTheme, setIsThemeReady, theme]);
+
+    const getIconTheme = useCallback((): ThemeOption | null => {
+        if (!resolvedTheme) {
+            return null;
+        }
+
+        if (currentTheme === "system") {
+            return resolvedTheme as ThemeOption;
+        }
+
+        return currentTheme;
+    }, [currentTheme, resolvedTheme]);
+
+    const toggleTheme = useCallback(() => {
+        if (!resolvedTheme) {
+            return;
+        }
+
+        const nextTheme = (resolvedTheme === "dark" ? "light" : "dark") as ThemeOption;
+        const applyTheme = () => {
+            setTheme(nextTheme);
+            setCurrentTheme(nextTheme);
         };
-    }, [isHolding, handleMouseMove, handleMouseUp]);
 
-    const handleClick = () => {
-        if (!isHolding) {
-            const newTheme = resolvedTheme === "dark" ? "light" : "dark";
-            setSwitchTheme(newTheme);
-            setTheme(newTheme);
+        if (typeof document === "undefined") {
+            applyTheme();
+            return;
         }
-    };
 
-    const getThemeIcon = (theme: ThemeOption) => {
-        switch (theme) {
-            case "dark":
-                return <BiMoon className={"w-8 h-8 text-theme-500"}/>;
-            case "light":
-                return <BiSun className={"w-8 h-8 text-theme-500"}/>;
-            case "system":
-                return(
-                    <>
-                        <BiDesktop className={"w-8 h-8 text-theme-500 hidden md:block"}/>
-                        <BiMobile className={"w-8 h-8 text-theme-500 block md:hidden"}/>
-                    </>
-                );
+        const doc = document as DocumentWithViewTransition;
+        const button = buttonRef.current;
+
+        if (button && doc.startViewTransition) {
+            const rect = button.getBoundingClientRect();
+            const x = rect.left + rect.width / 2;
+            const y = rect.top + rect.height / 2;
+
+            document.documentElement.style.setProperty("--theme-transition-x", `${x}px`);
+            document.documentElement.style.setProperty("--theme-transition-y", `${y}px`);
+
+            const transition = doc.startViewTransition(() => {
+                applyTheme();
+            });
+
+            transition.finished.finally(() => {
+                document.documentElement.style.removeProperty("--theme-transition-x");
+                document.documentElement.style.removeProperty("--theme-transition-y");
+            });
+
+            return;
         }
-    };
 
-    const getButtonThemeIcon = () => {
-        if (switchTheme === "system") {
-            return resolvedTheme === "dark"
-                ? <BiMoon className={"w-8 h-8 text-theme-500"} />
-                : <BiSun className={"w-8 h-8 text-theme-500"} />;
-        }
-        return getThemeIcon(switchTheme);
-    };
+        applyTheme();
+    }, [resolvedTheme, setTheme, setCurrentTheme]);
 
-    if (!isThemeResolved) {
-        return null; // Render nothing until the theme is resolved
+    const iconTheme = getIconTheme();
+
+    if (!isThemeReady || !iconTheme) {
+        return null;
     }
 
     return (
-        <>
-            <button
-                ref={buttonRef}
-                onMouseDown={handleMouseDown}
-                onClick={handleClick}
-                className={"flex items-center justify-center p-1.5"}
-                onMouseUp={(e) => handleMouseUp(e.nativeEvent)}
-            >
-                {getButtonThemeIcon()}
-            </button>
-            <Portal.Root>
-                <div
-                    ref={stadiumRef}
-                    className={cn(
-                        "fixed z-50",
-                        "rounded-md flex justify-between items-center p-0.5",
-                        "bg-theme-200/75 dark:bg-theme-800/75 backdrop-blur-3xl",
-                        "transition-opacity duration-300",
-                        isHolding ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
-                    )}
-                    style={{
-                        top: buttonRef.current?.getBoundingClientRect().top ?? 0, // Align with the top of the button
-                        left: buttonRef.current
-                            ? buttonRef.current.getBoundingClientRect().left -
-                            (stadiumRef.current?.offsetWidth ?? 0) - 6 // Position left of the button with some space
-                            : 0,
-                        transform: 'translateX()', // Horizontal translation to adjust positioning
-                    }}
-                >
-                    {(["dark", "system", "light"] as ThemeOption[]).map((option) => (
-                        <span
-                            key={option}
-                            className={cn(
-                                highlightedOption === option && "text-blue-500 bg-theme-300/25",
-                                "p-1.5 rounded-md"
-                            )}>
-                        {getThemeIcon(option)}
-                    </span>
-                    ))}
-                </div>
-            </Portal.Root>
-        </>
+        <button
+            ref={buttonRef}
+            type="button"
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+            className={"flex items-center justify-center p-1.5"}
+        >
+            {iconTheme === "dark"
+                ? <BiMoon className={"w-8 h-8 text-theme-500"} />
+                : <BiSun className={"w-8 h-8 text-theme-500"} />}
+        </button>
     );
 };
 


### PR DESCRIPTION
## Summary
- replace the long-press theme switcher with a simple toggle that defaults to system and persists the selected theme
- integrate View Transitions to animate theme changes from the toggle button with a radial mask effect
- enable the Next.js viewTransition experiment and add global styles to support the new animation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df4f4c16808323b483a06589879a19